### PR TITLE
Make failing job actually fail on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
       # Should be skipped as the mint step is expected to fail
       - name: Check
         if: ${{ steps.mint.outcome == 'success' }}
-        run: >-
+        run: |
           echo '${{ steps.mint.outputs.api-token }}'
-          && exit 1
+          exit 1
 
   pass:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
       # Should be skipped as the mint step is expected to fail
       - name: Check
         if: ${{ steps.mint.outcome == 'success' }}
-        run: echo '${{ steps.mint.outputs.api-token }}'
+        run: >-
+          echo '${{ steps.mint.outputs.api-token }}'
+          && exit 1
 
   pass:
     strategy:


### PR DESCRIPTION
Currently, if the job fails, calling `echo` has the return code of 0 which is success. To actually detect that something is wrong, it's necessary to reproduce that erroneous return code.